### PR TITLE
chore: Use Rust stable only and use cargo check #7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 rust:
   - stable
   - beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: rust
 rust:
-- stable
-- nightly
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+    - rust: beta
 script:
 - rustup component add rustfmt-preview
 - cargo fmt --all -- --check
-- cargo build --verbose
 - cargo test --verbose
 - cargo doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
   allow_failures:
     - rust: nightly
     - rust: beta
+  fast_finish: true
 script:
 - rustup component add rustfmt-preview
 - cargo fmt --all -- --check


### PR DESCRIPTION
- Use Rust `stable` channel as default, while allowing failures for `nightly` and `beta` channels
- Use `cargo check` instead of `cargo build`
- Close #7 